### PR TITLE
implement instancelock timeout

### DIFF
--- a/utils/instance_lock.py
+++ b/utils/instance_lock.py
@@ -35,10 +35,9 @@ class InstanceLock:
 
         # check if timeout has passed
         if epoch - instance.timestamp >= INSTANCE_TIMEOUT:
-            # free a slot, no need to delete it (if active_instances == 0) because it will be used in acquire
+            # free a slot, no need to delete it (if active_instances == 0) nor set new timestamp because it will be used in acquire
             instance.active_instances -= 1
             self.instances_len -= 1
-            instance.timestamp = epoch
 
     async def acquire(self, disc_userid: int) -> None:
         async with self.lock:


### PR DESCRIPTION
Let `Instance.timestamp` be the epoch of the last point in time when an instance got acquired. When attempting to acquire a new slot, check if `INSTANCE_TIMEOUT` seconds has passed (if possible), if so then free a slot.

Therefore, if some bug happens and a slot cannot be freed, we can just ignore it and eventually move on.