### PR TITLE
Save compatibility 

### DIFF
--- a/app_core/createsave.py
+++ b/app_core/createsave.py
@@ -15,7 +15,7 @@ from utils.constants import (
     SCE_SYS_NAME, PARAM_NAME, SCE_SYS_CONTENTS, RANDOMSTRING_LENGTH, MOUNT_LOCATION, PS_UPLOADDIR
 )
 from utils.workspace import cleanup
-from utils.orbis import validate_savedirname, sys_files_validator, sfo_ctx_create, sfo_ctx_write, sfo_ctx_patch_parameters, obtainCUSA
+from utils.orbis import validate_savedirname, sys_files_validator, sfo_ctx_create, sfo_ctx_write, sfo_ctx_patch_parameters, obtainCUSA, fix_pfs_hdr_hash2
 from utils.exceptions import OrbisError
 from utils.conversions import mb_to_saveblocks, saveblocks_to_bytes, bytes_to_mb
 from utils.extras import generate_random_string
@@ -158,9 +158,11 @@ class Createsave(TabBase):
 
             # download save at real filename path
             ftp_ctx = await C1ftp.create_ctx()
-            await C1ftp.download_stream(ftp_ctx, PS_UPLOADDIR + "/" + temp_savename, os.path.join(save_dirs, savename)),
-            await C1ftp.download_stream(ftp_ctx, PS_UPLOADDIR + "/" + temp_savename + ".bin", os.path.join(save_dirs, savename + ".bin"))
+            savepath = os.path.join(save_dirs, savename)
+            await C1ftp.download_stream(ftp_ctx, PS_UPLOADDIR + "/" + temp_savename, savepath),
+            await C1ftp.download_stream(ftp_ctx, PS_UPLOADDIR + "/" + temp_savename + ".bin", savepath + ".bin")
             await C1ftp.free_ctx(ftp_ctx)
+            await fix_pfs_hdr_hash2(savepath)
         except (SocketError, FTPError, OrbisError, OSError) as e:
             await cleanup(C1ftp, None, save, mount_paths)
             self.logger.error(f"`{str(e)}` Stopping...")

--- a/app_core/createsave.py
+++ b/app_core/createsave.py
@@ -15,7 +15,7 @@ from utils.constants import (
     SCE_SYS_NAME, PARAM_NAME, SCE_SYS_CONTENTS, RANDOMSTRING_LENGTH, MOUNT_LOCATION, PS_UPLOADDIR
 )
 from utils.workspace import cleanup
-from utils.orbis import validate_savedirname, sys_files_validator, sfo_ctx_create, sfo_ctx_write, sfo_ctx_patch_parameters, obtainCUSA, fix_pfs_hdr_hash2
+from utils.orbis import validate_savedirname, sys_files_validator, sfo_ctx_create, sfo_ctx_write, sfo_ctx_patch_parameters, obtainCUSA, fix_pfs_auth_code_info
 from utils.exceptions import OrbisError
 from utils.conversions import mb_to_saveblocks, saveblocks_to_bytes, bytes_to_mb
 from utils.extras import generate_random_string
@@ -162,7 +162,7 @@ class Createsave(TabBase):
             await C1ftp.download_stream(ftp_ctx, PS_UPLOADDIR + "/" + temp_savename, savepath),
             await C1ftp.download_stream(ftp_ctx, PS_UPLOADDIR + "/" + temp_savename + ".bin", savepath + ".bin")
             await C1ftp.free_ctx(ftp_ctx)
-            await fix_pfs_hdr_hash2(savepath)
+            await fix_pfs_auth_code_info(savepath)
         except (SocketError, FTPError, OrbisError, OSError) as e:
             await cleanup(C1ftp, None, save, mount_paths)
             self.logger.error(f"`{str(e)}` Stopping...")

--- a/cogs/createsave.py
+++ b/cogs/createsave.py
@@ -23,7 +23,7 @@ from utils.embeds import (
 )
 from utils.workspace import make_workspace, init_workspace, cleanup
 from utils.helpers import DiscordContext, error_handling, upload2, send_final, psusername, upload2_special, task_handler
-from utils.orbis import sfo_ctx_patch_parameters, obtainCUSA, validate_savedirname, sfo_ctx_create, sfo_ctx_write, sys_files_validator
+from utils.orbis import sfo_ctx_patch_parameters, obtainCUSA, validate_savedirname, sfo_ctx_create, sfo_ctx_write, sys_files_validator, fix_pfs_hdr_hash2
 from utils.exceptions import PSNIDError, FileError, OrbisError, WorkspaceError, TaskCancelledError
 from utils.instance_lock import INSTANCE_LOCK_global
 from utils.conversions import saveblocks_to_bytes, mb_to_saveblocks
@@ -178,12 +178,14 @@ class CreateSave(commands.Cog):
 
             # download save at real filename path
             ftp_ctx = await C1ftp.create_ctx()
+            savepath = os.path.join(save_dirs, savename)
             tasks = [
-                lambda: C1ftp.download_stream(ftp_ctx, PS_UPLOADDIR + "/" + temp_savename, os.path.join(save_dirs, savename)),
-                lambda: C1ftp.download_stream(ftp_ctx, PS_UPLOADDIR + "/" + temp_savename + ".bin", os.path.join(save_dirs, savename + ".bin"))
+                lambda: C1ftp.download_stream(ftp_ctx, PS_UPLOADDIR + "/" + temp_savename, savepath),
+                lambda: C1ftp.download_stream(ftp_ctx, PS_UPLOADDIR + "/" + temp_savename + ".bin", savepath + ".bin")
             ]
             await task_handler(d_ctx, tasks, [])
             await C1ftp.free_ctx(ftp_ctx)
+            await fix_pfs_hdr_hash2(savepath)
         except (SocketError, FTPError, OSError, OrbisError, TaskCancelledError) as e:
             status = "expected"
             if isinstance(e, OSError) and e.errno in CON_FAIL:

--- a/cogs/createsave.py
+++ b/cogs/createsave.py
@@ -23,7 +23,7 @@ from utils.embeds import (
 )
 from utils.workspace import make_workspace, init_workspace, cleanup
 from utils.helpers import DiscordContext, error_handling, upload2, send_final, psusername, upload2_special, task_handler
-from utils.orbis import sfo_ctx_patch_parameters, obtainCUSA, validate_savedirname, sfo_ctx_create, sfo_ctx_write, sys_files_validator, fix_pfs_hdr_hash2
+from utils.orbis import sfo_ctx_patch_parameters, obtainCUSA, validate_savedirname, sfo_ctx_create, sfo_ctx_write, sys_files_validator, fix_pfs_auth_code_info
 from utils.exceptions import PSNIDError, FileError, OrbisError, WorkspaceError, TaskCancelledError
 from utils.instance_lock import INSTANCE_LOCK_global
 from utils.conversions import saveblocks_to_bytes, mb_to_saveblocks
@@ -185,7 +185,7 @@ class CreateSave(commands.Cog):
             ]
             await task_handler(d_ctx, tasks, [])
             await C1ftp.free_ctx(ftp_ctx)
-            await fix_pfs_hdr_hash2(savepath)
+            await fix_pfs_auth_code_info(savepath)
         except (SocketError, FTPError, OSError, OrbisError, TaskCancelledError) as e:
             status = "expected"
             if isinstance(e, OSError) and e.errno in CON_FAIL:

--- a/network/ftp_functions.py
+++ b/network/ftp_functions.py
@@ -256,6 +256,8 @@ class FTPps:
             logger.error("Failed to connect to FTP!")
             raise FTPError("FTP ERROR!")
 
+        return new_savepath
+
     async def uploadencrypted_bulk(self, savename: str) -> None:
         savefiles = [os.path.join(self.upload_encrypted_path, savename), os.path.join(self.upload_encrypted_path, savename + ".bin")]
 

--- a/utils/orbis.py
+++ b/utils/orbis.py
@@ -6,6 +6,7 @@ import struct
 import shutil
 from enum import Enum
 from dataclasses import dataclass
+from Crypto.Cipher import AES
 
 from data.crypto.helpers import extra_reregion_pre, extra_reregion_pre_needs_folder
 from network.ftp_functions import FTPps
@@ -127,7 +128,8 @@ class SaveFile:
         await sfo_ctx_write(self.sfo_ctx, self.batch.fInstance.sfo_file_path)
         await self.batch.fInstance.upload_sfo(self.batch.location_to_scesys)
         await self.batch.sInstance.socket_update(self.batch.mount_location, self.realSave)
-        await self.batch.fInstance.dlencrypted_bulk(self.batch.user_id, self.realSave, self.title_id, self.reregion_check)
+        savepath = await self.batch.fInstance.dlencrypted_bulk(self.batch.user_id, self.realSave, self.title_id, self.reregion_check)
+        await fix_pfs_hdr_hash2(savepath)
 
     async def download_sys_elements(self, elements: list[ElementChoice]) -> None:
         for element in elements:
@@ -529,4 +531,34 @@ def sys_files_validator(sys_files: list[str]) -> None:
             n += 1
     if n != n_mandatory:
         raise OrbisError("All mandatory sce_sys files are not present!")
+
+async def fix_pfs_hdr_hash2(path: str) -> None:
+    # we may assume that the savefile is valid (it has been processed by the console)
+    HDR_HASH_OFF            = 0x380
+    HDR_HASH_SIZE           = 0x20
+
+    AUTH_CODE_OFF           = 0x7F90
+    AUTH_CODE_HDR_HASH2_OFF = AUTH_CODE_OFF + 0x40
+    AUTH_CODE_SIZE          = 0x70
+    KEY = bytes([
+        0x2B, 0xCF, 0x69, 0x8E, 0x79, 0xCF, 0xDD, 0xFA,
+        0xC2, 0x4D, 0x4C, 0x25, 0xBF, 0x35, 0x1E, 0x62
+    ])
+
+    async with aiofiles.open(path) as pfs:
+        await pfs.seek(HDR_HASH_OFF)
+        hash = await pfs.read(HDR_HASH_SIZE)
+
+        # we can start in the middle of the ciphertext
+        await pfs.seek(AUTH_CODE_HDR_HASH2_OFF - 16)
+        chunk = await pfs.read(16 + AUTH_CODE_SIZE - (AUTH_CODE_HDR_HASH2_OFF - AUTH_CODE_OFF))
+        iv = chunk[:16]
+        chunk = bytearray(chunk[16:])
+
+        AES.new(KEY, AES.MODE_CBC, iv).decrypt(chunk, chunk)
+        chunk[:HDR_HASH_SIZE] = hash
+        AES.new(KEY, AES.MODE_CBC, iv).encrypt(chunk, chunk)
+
+        await pfs.seek(AUTH_CODE_HDR_HASH2_OFF)
+        await pfs.write(chunk)
 

--- a/utils/orbis.py
+++ b/utils/orbis.py
@@ -540,12 +540,21 @@ async def fix_pfs_hdr_hash2(path: str) -> None:
     AUTH_CODE_OFF           = 0x7F90
     AUTH_CODE_HDR_HASH2_OFF = AUTH_CODE_OFF + 0x40
     AUTH_CODE_SIZE          = 0x70
+
+    AUTH_CODE_MAGIC = bytes([
+        0x79, 0x2B, 0x1A, 0xC1, 0xBB, 0x9B, 0x9A, 0x45
+    ])
     KEY = bytes([
         0x2B, 0xCF, 0x69, 0x8E, 0x79, 0xCF, 0xDD, 0xFA,
         0xC2, 0x4D, 0x4C, 0x25, 0xBF, 0x35, 0x1E, 0x62
     ])
 
-    async with aiofiles.open(path) as pfs:
+    async with aiofiles.open(path, "r+b") as pfs:
+        await pfs.seek(AUTH_CODE_OFF)
+        magic = await pfs.read(len(AUTH_CODE_MAGIC))
+        if magic != AUTH_CODE_MAGIC:
+            return
+
         await pfs.seek(HDR_HASH_OFF)
         hash = await pfs.read(HDR_HASH_SIZE)
 
@@ -557,6 +566,8 @@ async def fix_pfs_hdr_hash2(path: str) -> None:
 
         AES.new(KEY, AES.MODE_CBC, iv).decrypt(chunk, chunk)
         chunk[:HDR_HASH_SIZE] = hash
+        if chunk[HDR_HASH_SIZE:HDR_HASH_SIZE + 8] == bytes(8):
+            chunk[HDR_HASH_SIZE:HDR_HASH_SIZE + 8] = b"\x01\x00\x00\x00\x00\x00\x00\x00"
         AES.new(KEY, AES.MODE_CBC, iv).encrypt(chunk, chunk)
 
         await pfs.seek(AUTH_CODE_HDR_HASH2_OFF)

--- a/utils/orbis.py
+++ b/utils/orbis.py
@@ -129,7 +129,7 @@ class SaveFile:
         await self.batch.fInstance.upload_sfo(self.batch.location_to_scesys)
         await self.batch.sInstance.socket_update(self.batch.mount_location, self.realSave)
         savepath = await self.batch.fInstance.dlencrypted_bulk(self.batch.user_id, self.realSave, self.title_id, self.reregion_check)
-        await fix_pfs_hdr_hash2(savepath)
+        await fix_pfs_auth_code_info(savepath)
 
     async def download_sys_elements(self, elements: list[ElementChoice]) -> None:
         for element in elements:
@@ -532,7 +532,7 @@ def sys_files_validator(sys_files: list[str]) -> None:
     if n != n_mandatory:
         raise OrbisError("All mandatory sce_sys files are not present!")
 
-async def fix_pfs_hdr_hash2(path: str) -> None:
+async def fix_pfs_auth_code_info(path: str) -> None:
     # we may assume that the savefile is valid (it has been processed by the console)
     HDR_HASH_OFF            = 0x380
     HDR_HASH_SIZE           = 0x20
@@ -565,7 +565,9 @@ async def fix_pfs_hdr_hash2(path: str) -> None:
         chunk = bytearray(chunk[16:])
 
         AES.new(KEY, AES.MODE_CBC, iv).decrypt(chunk, chunk)
+        # fix pfs_hdr_hash2
         chunk[:HDR_HASH_SIZE] = hash
+        # make sure copy_ctr is nonzero
         if chunk[HDR_HASH_SIZE:HDR_HASH_SIZE + 8] == bytes(8):
             chunk[HDR_HASH_SIZE:HDR_HASH_SIZE + 8] = b"\x01\x00\x00\x00\x00\x00\x00\x00"
         AES.new(KEY, AES.MODE_CBC, iv).encrypt(chunk, chunk)


### PR DESCRIPTION
Mounted saves from the console has an invalid `pfs_hdr_hash2` value in `auth_code_info`, this PR fixes that on the bot's and app's end and makes sure the `copy_counter` is nonzero as well.
This PR should make encrypted saves from HTOS work on Save Wizard.
This PR is credited to @B-a-t-a-n-g.