### PR TITLE
special reregion fix

### DIFF
--- a/data/crypto/helpers.py
+++ b/data/crypto/helpers.py
@@ -842,7 +842,7 @@ def extra_reregion_pre_needs_folder(
 async def extra_reregion_post(
           savepath: str,
           title_id: str,
-        ) -> None:
+        ) -> str | None:
     """
     On encrypted savepairs.
     Renames the save after re-regioning for the games that need it, random string is appended at the end for no overwriting.
@@ -876,4 +876,5 @@ async def extra_reregion_post(
         new_file = os.path.join(savefolder, new_name + f"_{rand_str}")
     await aiofiles.os.rename(savepath, new_file)
     await aiofiles.os.rename(savepath + ".bin", new_file + ".bin")
+    return new_file
 

--- a/network/ftp_functions.py
+++ b/network/ftp_functions.py
@@ -7,7 +7,6 @@ import aiofiles.os
 import asyncio
 from aioftp.errors import AIOFTPException
 
-from data.crypto.helpers import extra_reregion_post
 from network.exceptions import FTPError
 from utils.constants import GENERAL_CHUNKSIZE, SYS_FILE_MAX, KEYSTONE_SIZE, KEYSTONE_NAME, PARAM_NAME, ICON0_NAME, SCE_SYS_NAME, logger
 from utils.embeds import embuplSuccess
@@ -232,7 +231,7 @@ class FTPps:
             logger.error("Failed to connect to FTP!")
             raise FTPError("FTP ERROR!")
 
-    async def dlencrypted_bulk(self, account_id: str, savename: str, title_id: str, reregion: bool = False) -> str:
+    async def dlencrypted_bulk(self, account_id: str, savename: str, title_id: str) -> str:
         savefilespath = os.path.join(self.download_encrypted_path, "PS4", "SAVEDATA", account_id, title_id)
         await aiofiles.os.makedirs(savefilespath, exist_ok=True)
 
@@ -247,9 +246,6 @@ class FTPps:
                 new_savenames_bin = new_savename + ".bin"
                 new_savepath_bin = os.path.join(savefilespath, new_savenames_bin)
                 await self.download_stream(ftp, savename_bin, new_savepath_bin)
-
-            if reregion:
-                await extra_reregion_post(new_savepath, title_id)
 
         except AIOFTPException as e:
             logger.exception(f"[FTP ERROR]: {e}")

--- a/utils/orbis.py
+++ b/utils/orbis.py
@@ -8,7 +8,7 @@ from enum import Enum
 from dataclasses import dataclass
 from Crypto.Cipher import AES
 
-from data.crypto.helpers import extra_reregion_pre, extra_reregion_pre_needs_folder
+from data.crypto.helpers import extra_reregion_pre, extra_reregion_pre_needs_folder, extra_reregion_post
 from network.ftp_functions import FTPps
 from network.socket_functions import SocketPS
 from utils.constants import (
@@ -128,7 +128,11 @@ class SaveFile:
         await sfo_ctx_write(self.sfo_ctx, self.batch.fInstance.sfo_file_path)
         await self.batch.fInstance.upload_sfo(self.batch.location_to_scesys)
         await self.batch.sInstance.socket_update(self.batch.mount_location, self.realSave)
-        savepath = await self.batch.fInstance.dlencrypted_bulk(self.batch.user_id, self.realSave, self.title_id, self.reregion_check)
+        savepath = await self.batch.fInstance.dlencrypted_bulk(self.batch.user_id, self.realSave, self.title_id)
+        if self.reregion_check:
+            sp = await extra_reregion_post(savepath, self.title_id)
+            if sp is not None:
+                savepath = sp
         await fix_pfs_auth_code_info(savepath)
 
     async def download_sys_elements(self, elements: list[ElementChoice]) -> None:


### PR DESCRIPTION
Games that change the save name in the `reregion` command had the old path passed in `fix_pfs_auth_code_info`.